### PR TITLE
Adding system level credentials. If your default service account for …

### DIFF
--- a/build.txt
+++ b/build.txt
@@ -1,0 +1,1 @@
+GOOS=linux GOARCH=amd64 go build -x -o ./gcp_vault_secret .


### PR DESCRIPTION
…the VM works, then you can use this and avoid shipping any long lived service account keys around.